### PR TITLE
add cluster subcommand, and combine cluster start and bcbio bootstrap

### DIFF
--- a/bcbiovm/aws/bootstrap.py
+++ b/bcbiovm/aws/bootstrap.py
@@ -7,37 +7,6 @@ import toolz as tz
 
 from bcbiovm.aws import common
 
-def setup_cmd(awsparser):
-    parser_sub_b = awsparser.add_parser("bcbio", help="Manage bcbio on AWS systems")
-    parser_b = parser_sub_b.add_subparsers(title="[bcbio specific actions]")
-
-    parser = parser_b.add_parser("bootstrap",
-                                 help="Update a bcbio AWS system with the latest code and tools",
-                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser = _add_default_ec_args(parser)
-    parser.add_argument("-R", "--no-reboot",
-                        default=False, action="store_true",
-                        help="Don't upgrade the cluster host OS and reboot")
-    parser.add_argument("-v", "--verbose", action="count", default=0,
-                        help="Emit verbose output when running "
-                             "Ansible playbooks")
-    parser.set_defaults(func=bootstrap)
-
-    parser = parser_b.add_parser("run",
-                                 help="Run a script on the bcbio frontend node inside a screen session",
-                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser = _add_default_ec_args(parser)
-    parser.add_argument("script", help=("Path to a script to run. "
-                                        "The screen session name is the basename of the script."))
-    parser.set_defaults(func=run_remote)
-
-def _add_default_ec_args(parser):
-    parser.add_argument("--econfig", help="Elasticluster bcbio configuration file",
-                        default=common.DEFAULT_EC_CONFIG)
-    parser.add_argument("-c", "--cluster", default="bcbio",
-                        help="elasticluster cluster name")
-    return parser
-
 # ## Bootstrap a new instance
 
 # Core and memory usage for AWS instances
@@ -107,33 +76,3 @@ def _bootstrap_bcbio(args, ansible_base):
 
     common.run_ansible_pb(
         inventory_path, playbook_path, args, _extra_vars)
-
-# ## Run a remote command
-
-def run_remote(args):
-    """Run a script on the frontend node inside a screen session.
-    """
-    config = common.ecluster_config(args.econfig)
-    cluster = config.load_cluster(args.cluster)
-
-    frontend = cluster.get_frontend_node()
-    client = frontend.connect(keyfile=cluster.known_hosts_file)
-
-    cmd = "echo $HOME"
-    stdin, stdout, stderr = client.exec_command(cmd)
-    remote_home = stdout.read().strip()
-    remote_file = os.path.join(remote_home, os.path.basename(args.script))
-    log_file = "%s.log" % os.path.splitext(remote_file)[0]
-    screen_name = os.path.splitext(os.path.basename(remote_file))[0]
-
-    sftp = client.open_sftp()
-    sftp.put(args.script, remote_file)
-    sftp.close()
-
-    cmd = "chmod a+x %s" % remote_file
-    client.exec_command(cmd)
-    cmd = "screen -d -m -S %s bash -c '%s &> %s'" % (screen_name, remote_file, log_file)
-    stdin, stdout, stderr = client.exec_command(cmd)
-    stdout.read()
-    client.close()
-    print("Running %s on AWS in screen session %s" % (remote_file, screen_name))

--- a/bcbiovm/aws/cluster.py
+++ b/bcbiovm/aws/cluster.py
@@ -1,0 +1,127 @@
+"""Manage a cluster's life cycle."""
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+
+from bcbiovm.aws import bootstrap, common
+
+def setup_cmd(awsparser):
+    parser_sub_b = awsparser.add_parser("cluster", help="Manage AWS clusters")
+    parser_b = parser_sub_b.add_subparsers(title="[cluster specific actions]")
+
+    parser = parser_b.add_parser("bootstrap",
+                                 help="Update a bcbio AWS system with "
+                                      "the latest code and tools",
+                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser = common.add_default_ec_args(parser)
+    parser.add_argument("-R", "--no-reboot",
+                        default=False, action="store_true",
+                        help="Don't upgrade the cluster host OS and reboot")
+    parser.add_argument("-v", "--verbose", action="count", default=0,
+                        help="Emit verbose output when running "
+                             "Ansible playbooks")
+    parser.set_defaults(func=bootstrap_cluster)
+
+    parser = parser_b.add_parser("command",
+                                 help="Run a script on the bcbio frontend "
+                                      "node inside a screen session",
+                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser = common.add_default_ec_args(parser)
+    parser.add_argument("script", metavar="SCRIPT",
+                        help="Local path of the script to run. The screen "
+                             "session name is the basename of the script.")
+    parser.set_defaults(func=run_remote)
+
+    parser = parser_b.add_parser("ssh", help="SSH to a bcbio cluster",
+                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser = common.add_default_ec_args(parser)
+    parser.add_argument("-v", "--verbose", action="count", default=0,
+                        help="Emit verbose output when running "
+                             "Ansible playbooks")
+    parser.add_argument("args", metavar="ARG", nargs="*",
+                        help="Execute the following command on the remote "
+                             "machine instead of opening an interactive shell.")
+    parser.set_defaults(func=ssh)
+
+    parser = parser_b.add_parser("start", help="Start a bcbio cluster",
+                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser = common.add_default_ec_args(parser)
+    parser.add_argument("-v", "--verbose", action="count", default=0,
+                        help="Emit verbose output when running "
+                             "Ansible playbooks")
+    parser.set_defaults(func=start)
+
+    parser = parser_b.add_parser("stop", help="Stop a bcbio cluster",
+                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser = common.add_default_ec_args(parser)
+    parser.add_argument("-v", "--verbose", action="count", default=0,
+                        help="Emit verbose output when running "
+                             "Ansible playbooks")
+    parser.set_defaults(func=stop)
+
+
+def bootstrap_cluster(args):
+    """Bootstrap bcbio, or upgrade bcbio on an existing cluster."""
+    bootstrap.bootstrap(args)
+
+
+# ## Run a remote command
+
+def run_remote(args):
+    """Run a script on the frontend node inside a screen session."""
+    config = common.ecluster_config(args.econfig)
+    cluster = config.load_cluster(args.cluster)
+
+    frontend = cluster.get_frontend_node()
+    client = frontend.connect(keyfile=cluster.known_hosts_file)
+
+    cmd = "echo $HOME"
+    stdin, stdout, stderr = client.exec_command(cmd)
+    remote_home = stdout.read().strip()
+    remote_file = os.path.join(remote_home, os.path.basename(args.script))
+    log_file = "%s.log" % os.path.splitext(remote_file)[0]
+    screen_name = os.path.splitext(os.path.basename(remote_file))[0]
+
+    sftp = client.open_sftp()
+    sftp.put(args.script, remote_file)
+    sftp.close()
+
+    cmd = "chmod a+x %s" % remote_file
+    client.exec_command(cmd)
+    cmd = "screen -d -m -S {} bash -c '{} &> {}'".format(
+        screen_name, remote_file, log_file)
+    stdin, stdout, stderr = client.exec_command(cmd)
+    stdout.read()
+    client.close()
+    print("Running {} on AWS in screen session {}".format(
+        remote_file, screen_name))
+
+
+def ssh(args):
+    """SSH to a cluster."""
+    ec_args = ["elasticluster", "ssh", args.cluster]
+    if args.verbose:
+        ec_args.append("-{}".format(args.verbose * "v"))
+    ec_args.extend(args.args)
+    sys.exit(common.wrap_elasticluster(ec_args))
+
+
+def start(args):
+    """Start and bootstrap a cluster."""
+    ec_args = ["elasticluster", "start", args.cluster]
+    if args.verbose:
+        ec_args.append("-{}".format(args.verbose * "v"))
+    status = common.wrap_elasticluster(ec_args)
+    if status != 0:
+        sys.exit(status)
+    bootstrap_cluster(args)
+
+
+def stop(args):
+    """Stop a cluster."""
+    ec_args = ["elasticluster", "stop", args.cluster]
+    if args.verbose:
+        ec_args.append("-{}".format(args.verbose * "v"))
+    sys.exit(common.wrap_elasticluster(ec_args))

--- a/bcbiovm/aws/iam.py
+++ b/bcbiovm/aws/iam.py
@@ -2,6 +2,8 @@
 
 http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
 """
+from __future__ import print_function
+
 import datetime
 import os
 import shutil

--- a/bcbiovm/aws/icel.py
+++ b/bcbiovm/aws/icel.py
@@ -45,13 +45,10 @@ def setup_cmd(awsparser):
     parser = icel_parser.add_parser("create",
                                     help="Create scratch filesystem using Intel Cloud Edition for Lustre",
                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument("--econfig", help="Elasticluster bcbio configuration file",
-                        default=common.DEFAULT_EC_CONFIG)
+    parser = common.add_default_ec_args(parser)
     parser.add_argument("--recreate", action="store_true", default=False,
                         help="Remove and recreate the stack, "
                              "destroying all data stored on it")
-    parser.add_argument("-c", "--cluster", default="bcbio",
-                        help="elasticluster cluster name")
     parser.add_argument("-v", "--verbose", action="count", default=0,
                         help="Emit verbose output when running "
                              "Ansible playbooks")
@@ -79,10 +76,7 @@ def setup_cmd(awsparser):
     parser = icel_parser.add_parser("fs_spec",
                                     help="Get the filesystem spec for a running filesystem",
                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument("--econfig", help="Elasticluster bcbio configuration file",
-                        default=common.DEFAULT_EC_CONFIG)
-    parser.add_argument("-c", "--cluster", default="bcbio",
-                        help="elasticluster cluster name")
+    parser = common.add_default_ec_args(parser)
     parser.add_argument(metavar="STACK_NAME", dest="stack_name", nargs="?",
                         default="bcbiolustre",
                         help="CloudFormation name for the stack")
@@ -93,10 +87,7 @@ def setup_cmd(awsparser):
     parser = icel_parser.add_parser("mount",
                                     help="Mount Lustre filesystem on all cluster nodes",
                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument("--econfig", help="Elasticluster bcbio configuration file",
-                        default=common.DEFAULT_EC_CONFIG)
-    parser.add_argument("-c", "--cluster", default="bcbio",
-                        help="elasticluster cluster name")
+    parser = common.add_default_ec_args(parser)
     parser.add_argument("-v", "--verbose", action="count", default=0,
                         help="Emit verbose output when running "
                              "Ansible playbooks")
@@ -110,10 +101,7 @@ def setup_cmd(awsparser):
     parser = icel_parser.add_parser("unmount",
                                     help="Unmount Lustre filesystem on all cluster nodes",
                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument("--econfig", help="Elasticluster bcbio configuration file",
-                        default=common.DEFAULT_EC_CONFIG)
-    parser.add_argument("-c", "--cluster", default="bcbio",
-                        help="elasticluster cluster name")
+    parser = common.add_default_ec_args(parser)
     parser.add_argument("-v", "--verbose", action="count", default=0,
                         help="Emit verbose output when running "
                              "Ansible playbooks")
@@ -127,10 +115,7 @@ def setup_cmd(awsparser):
     parser = icel_parser.add_parser("stop",
                                     help="Stop the running Lustre filesystem and clean up resources",
                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument("--econfig", help="Elasticluster bcbio configuration file",
-                        default=common.DEFAULT_EC_CONFIG)
-    parser.add_argument("-c", "--cluster", default="bcbio",
-                        help="elasticluster cluster name")
+    parser = common.add_default_ec_args(parser)
     parser.add_argument(metavar="STACK_NAME", dest="stack_name", nargs="?",
                         default="bcbiolustre",
                         help="CloudFormation name for the new stack")


### PR DESCRIPTION
Hey Brad, I combined 'elasticluster start' and 'aws bcbio bootstrap' into 'cluster start' - this seems a bunch nicer since I always wind up forgetting to bootstrap a cluster I've started.

It also changes 'aws bcbio run' to 'aws cluster command'. I can update the docs in bcbio-nextgen for all of this if you like.

The one remaining question is how to handle elasticluster's `-s` and `-c` args. Right now, you can pass them to `bcbio_vm.py elasticluster` and it will pass them through, but we use `-c` to specify a cluster name everywhere else. Any ideas on how we might want to deal with that? Maybe support environment variables for the elasticluster storage and config file paths, which would be nice if people want to override them since they can set them once in their shell dotfiles and not have to specify those args each time?


```
instead of:

  bcbio_vm.py elasticluster start bcbio
  bcbio_vm.py aws bcbio bootstrap

you can now simply:

  bcbio_vm.py aws cluster start

other commands that have changed:

bcbio_vm.py elasticluster ssh bcbio -> bcbio_vm.py aws cluster ssh
bcbio_vm.py elasticluster stop bcbio -> bcbio_vm.py aws cluster start
bcbio_vm.py aws bcbio run -> bcbio_vm.py aws cluster command
```