### PR TITLE
Fix BaseCommand.run bug

### DIFF
--- a/bcbiovm/client/base.py
+++ b/bcbiovm/client/base.py
@@ -142,7 +142,7 @@ class BaseCommand(object):
             self.command_fail(exc)
         else:
             self.command_done(result)
-        return result
+            return result
 
 
 @six.add_metaclass(abc.ABCMeta)


### PR DESCRIPTION
The result could have been referenced without defining.