### PR TITLE
Add requirements.txt that make bcbio-nextgen-vm clear a clean install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+ansible
+# Elasticluster PyPi issue:
+# https://github.com/gc3-uzh-ch/elasticluster/issues/147
+https://github.com/gc3-uzh-ch/elasticluster/archive/master.tar.gz
+# IPython parallel framework is splitting its parts in different repos
+https://github.com/roryk/ipython-cluster-helper/archive/master.tar.gz
+https://github.com/ipython/ipyparallel/archive/master.tar.gz
+ipython
+boto == 2.38.0
+toolz == 0.7.2
+matplotlib == 1.4.3
+numpy == 1.9.2
+paramiko == 1.15.2
+Requests == 2.7.0
+setuptools == 18.0.1
+six == 1.9.0
+PyYAML == 3.11


### PR DESCRIPTION
Mainly Elasticluster not being upstream on PyPi (https://github.com/roryk/ipython-cluster-helper/pull/30) and ipython-cluster-helper issues (see WWCRC Trello for further details).

@ohofmann