### PR TITLE
Serialize collectl plots to be able to slice/inspect them later on

### DIFF
--- a/bcbiovm/graph/graph.py
+++ b/bcbiovm/graph/graph.py
@@ -2,7 +2,9 @@ from __future__ import print_function
 
 import matplotlib
 matplotlib.use('Agg')
+import os
 import pylab
+import cPickle as pickle
 pylab.rcParams['figure.figsize'] = (35.0, 12.0)
 
 from bcbio import utils
@@ -22,6 +24,14 @@ def bootstrap(args):
                                                        cluster=args.cluster,
                                                        rawdir=args.rawdir,
                                                        verbose=args.verbose)
+
+    if args.serialize:
+        # Useful to regenerate and slice graphs quickly
+        collectl_info = (data, hardware, steps)
+
+        with open(os.path.join(args.outdir, "collectl_info.pickle"), "w") as f:
+            pickle.dump(collectl_info, f)
+ 
     bcbio_graph.generate_graphs(data_frames=data,
                                 hardware_info=hardware,
                                 steps=steps,

--- a/bcbiovm/graph/graph.py
+++ b/bcbiovm/graph/graph.py
@@ -26,12 +26,12 @@ def bootstrap(args):
                                                        verbose=args.verbose)
 
     if args.serialize:
-        # Useful to regenerate and slice graphs quickly
+        # Useful to regenerate and slice graphs quickly and/or inspect locally
         collectl_info = (data, hardware, steps)
 
-        with open(os.path.join(args.outdir, "collectl_info.pickle"), "w") as f:
+        with open(os.path.join(args.outdir, "collectl_info.pickle"), "wb") as f:
             pickle.dump(collectl_info, f)
- 
+
     bcbio_graph.generate_graphs(data_frames=data,
                                 hardware_info=hardware,
                                 steps=steps,

--- a/scripts/bcbio_vm.py
+++ b/scripts/bcbio_vm.py
@@ -222,6 +222,8 @@ def _graph_cmd(subparsers):
                         default=common.DEFAULT_EC_CONFIG)
     parser.add_argument("-v", "--verbose", action="store_true", default=False,
                         help="Emit verbose output")
+    parser.add_argument("-s", "--serialize", action="store_true", default=False,
+                        help="Serialize plot information for later faster inspection")
     parser.set_defaults(func=graph.bootstrap)
 
 def _aws_cmd(subparsers):


### PR DESCRIPTION
Useful to mangle generated data after running `bcbio_vm.py graph` (via jupyter notebook, for instance) without having to reprocess the data and plots (slow).