### PR TITLE
Serialize collectl graphs when dataframes are post-processed [ci skip]

### DIFF
--- a/bcbiovm/graph/graph.py
+++ b/bcbiovm/graph/graph.py
@@ -4,7 +4,6 @@ import matplotlib
 matplotlib.use('Agg')
 import os
 import pylab
-import cPickle as pickle
 pylab.rcParams['figure.figsize'] = (35.0, 12.0)
 
 from bcbio import utils
@@ -33,4 +32,4 @@ def bootstrap(args):
                                                 verbose=args.verbose)
 
     if args.serialize:
-        bcbio_graph.serialize_plot_data(collectl_info, "collectl_info.pickle.gz")
+        bcbio_graph.serialize_plot_data(collectl_info, args.outdir, "collectl_info.pickle.gz")

--- a/bcbiovm/graph/graph.py
+++ b/bcbiovm/graph/graph.py
@@ -25,15 +25,12 @@ def bootstrap(args):
                                                        rawdir=args.rawdir,
                                                        verbose=args.verbose)
 
+    # Collectl_info is cleaned up data ready to be plotted/mangled
+    collectl_info = bcbio_graph.generate_graphs(data_frames=data,
+                                                hardware_info=hardware,
+                                                steps=steps,
+                                                outdir=utils.safe_makedir(args.outdir),
+                                                verbose=args.verbose)
+
     if args.serialize:
-        # Useful to regenerate and slice graphs quickly and/or inspect locally
-        collectl_info = (data, hardware, steps)
-
-        with open(os.path.join(args.outdir, "collectl_info.pickle"), "wb") as f:
-            pickle.dump(collectl_info, f)
-
-    bcbio_graph.generate_graphs(data_frames=data,
-                                hardware_info=hardware,
-                                steps=steps,
-                                outdir=utils.safe_makedir(args.outdir),
-                                verbose=args.verbose)
+        bcbio_graph.serialize_plot_data(collectl_info, "collectl_info.pickle.gz")

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if "--record=/dev/null" in sys.argv:  # conda build
 else:
     install_requires = [
         "matplotlib", "pandas", "paramiko", "six", "PyYAML",
-        "bcbio-nextgen"]
+        "pythonpy", "bcbio-nextgen"]
 
 setup(name="bcbio-nextgen-vm",
       version=version,


### PR DESCRIPTION
Commit cleanup, thanks @chapmanb and @guillermo-carrasco, related to twin PR:

https://github.com/chapmanb/bcbio-nextgen/pull/1037

When preparing/installing for docker, it needs an additional dependency not installed by conda: `pythonpy`.