### PR TITLE
Correct installation structure

### DIFF
--- a/ansible/roles/bcbio_bootstrap/tasks/main.yml
+++ b/ansible/roles/bcbio_bootstrap/tasks/main.yml
@@ -30,7 +30,7 @@
   hosts: frontend*
   sudo: false
   vars:
-    anaconda_dir: "~{{ansible_user_id}}/install/bcbio-vm/anaconda"
+    anaconda_dir: "~{{ansible_user_id}}/install/bcbio-vm/data/anaconda"
   tasks:
     - name: Get Miniconda install script
       get_url:
@@ -73,7 +73,8 @@
   hosts: all
   sudo: false
   vars:
-    anaconda_dir: "~{{ansible_user_id}}/install/bcbio-vm/anaconda"
+    anaconda_dir: "~{{ansible_user_id}}/install/bcbio-vm/data/anaconda"
+    data_dir: "~{{ansible_user_id}}/install/bcbio-vm/data"
   tasks:
     - name: install collectl for run stats (deb)
       apt: name=collectl state=present
@@ -131,13 +132,19 @@
 
     - name: Upgrade bcbio-vm docker container with tools
       shell: >
-        bcbio_vm.py upgrade --tools
+        bcbio_vm.py --datadir={{data_dir}} upgrade --tools
         >/tmp/bcbio.log 2>&1
       args:
         executable: /bin/bash
       register: bcbio_vm_doupgrade
       async: 18000
       poll: 30
+
+    - name: Save current configuration
+      shell: >
+        bcbio_vm.py --datadir={{data_dir}} saveconfig
+      args:
+        executable: /bin/bash
 
     - command: "tail -100 /tmp/bcbio.log"
       register: bcbio_vm_debug


### PR DESCRIPTION
This fixes an issue in AWS were the anaconda installation was in `/home/ubuntu/install/bcbio-vm/anaconda`. The issue was caused by [this](https://github.com/chapmanb/bcbio-nextgen/blob/master/bcbio/pipeline/config_utils.py#L75) method trying to locate the system configuration file two directories above under `galaxy` directory. 

The structure now is 

```
ubuntu@frontend001:~$ ls install/bcbio-vm/data/
anaconda  config  galaxy  gemini_data  genomes  liftOver
```