### PR TITLE
Sync available genomes and indexes with bcbio-nextgen

### DIFF
--- a/bcbiovm/docker/devel.py
+++ b/bcbiovm/docker/devel.py
@@ -27,16 +27,23 @@ DOCKER = {"port": 8085,
           "work_dir": "/mnt/work",
           "image_url": "https://s3.amazonaws.com/bcbio_nextgen/bcbio-nextgen-docker-image.gz"}
 
+# Available genomes and indexes
+SUPPORTED_GENOMES = ["GRCh37", "hg19", "hg38", "hg38-noalt", "mm10", "mm9",
+                     "rn6", "rn5", "canFam3", "dm3", "galGal4", "phix",
+                     "pseudomonas_aeruginosa_ucbpp_pa14", "sacCer3", "TAIR10",
+                     "WBcel235", "xenTro3", "Zv9", "GRCz10"]
+SUPPORTED_INDEXES = ["bowtie", "bowtie2", "bwa", "novoalign", "rtg", "snap",
+                     "star", "ucsc", "seq", "hisat2"]
+
 def add_biodata_args(parser):
     """Add standard arguments for preparing biological data to a command line arg parser.
     """
     parser.add_argument("--genomes", help="Genomes to download",
                         action="append", default=[],
-                        choices=["GRCh37", "hg19", "mm10", "mm9", "rn5", "canFam3", "dm3", "Zv9", "phix",
-                                 "sacCer3", "xenTro3", "TAIR10", "WBcel235"])
+                        choices=SUPPORTED_GENOMES)
     parser.add_argument("--aligners", help="Aligner indexes to download",
                         action="append", default=[],
-                        choices=["bowtie", "bowtie2", "bwa", "novoalign", "star", "ucsc"])
+                        choices=SUPPORTED_INDEXES)
     return parser
 
 def setup_cmd(subparsers):


### PR DESCRIPTION
No sure this is correct, but I think that available genomes and indexes in `bcbio-nextgen` should be the same than those for `bcbio-nextgen-vm`, right?

Also, do you think it would be a good idea to load these available genomes and indexes from `bcbio_system.yaml` or similar instead of replicating theme among repos?